### PR TITLE
Import mastodon-lite to iotjs-modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,3 +24,6 @@
 [submodule "color-sensor-js"]
 	path = color-sensor-js
 	url = https://github.com/SamsungInternet/color-sensor-js
+[submodule "mastodon-lite"]
+	path = mastodon-lite
+	url = https://github.com/rzr/mastodon-lite


### PR DESCRIPTION
Origin: https://github.com/rzr/mastodon-lite
Change-Id: I774da49a3891f9e15338d716b31564db98570c88
Bug: https://github.com/pando-project/iotjs-modules/pull/
IoT.js-Modules-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com